### PR TITLE
Fix npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "babel-eslint": "^4.1.7",
     "babel-loader": "^5.3.2",
     "css-loader": "^0.15.5",
-    "cssnext-loader": "^1.0.1",
     "escope": "<=3.3.0",
     "eslint-loader": "^0.14.2",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "doc": "doc"
   },
   "dependencies": {
+    "babel": "^5.5.8",
     "eslint": "^0.23.0",
     "express": "^4.12.4",
-    "socket.io": "^1.3.5",
-    "babel": "^5.5.8"
+    "socket.io": "^1.3.5"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.7",
     "babel-loader": "^5.3.2",
-    "escope": "<=3.3.0",
     "css-loader": "^0.15.5",
     "cssnext-loader": "^1.0.1",
+    "escope": "<=3.3.0",
     "eslint-loader": "^0.14.2",
     "file-loader": "^0.8.4",
     "json-loader": "^0.5.2",


### PR DESCRIPTION
```
# npm audit report

braces  <2.3.1
Regular Expression Denial of Service - https://npmjs.com/advisories/786
fix available via `npm audit fix`
node_modules/braces
  micromatch  0.2.0 - 2.3.11
  Depends on vulnerable versions of braces
  node_modules/micromatch
    anymatch  1.2.0 - 1.3.2
    Depends on vulnerable versions of micromatch
    node_modules/anymatch
      chokidar  1.3.0 - 1.7.0
      Depends on vulnerable versions of anymatch
      node_modules/chokidar

debug  <=2.6.8 || 3.0.0 - 3.0.1
Regular Expression Denial of Service - https://npmjs.com/advisories/534
fix available via `npm audit fix --force`
Will install socket.io@4.0.0, which is a breaking change
node_modules/engine.io-client/node_modules/debug
node_modules/engine.io/node_modules/debug
node_modules/socket.io-adapter/node_modules/debug
node_modules/socket.io-client/node_modules/debug
node_modules/socket.io-parser/node_modules/debug
node_modules/socket.io/node_modules/debug
  engine.io  <=3.0.0
  Depends on vulnerable versions of debug
  node_modules/engine.io
  engine.io-client  <=3.1.1
  Depends on vulnerable versions of debug
  Depends on vulnerable versions of parsejson
  node_modules/engine.io-client
    socket.io-client  1.0.0-pre - 2.0.1
    Depends on vulnerable versions of debug
    Depends on vulnerable versions of engine.io-client
    node_modules/socket.io-client
      socket.io  <=2.3.0
      Depends on vulnerable versions of debug
      Depends on vulnerable versions of socket.io-client
      node_modules/socket.io
  socket.io-adapter  <=1.1.0
  Depends on vulnerable versions of debug
  Depends on vulnerable versions of socket.io-parser
  node_modules/socket.io-adapter
  socket.io-parser  1.1.0 - 3.0.0
  Depends on vulnerable versions of debug
  node_modules/socket.io-parser

handlebars  <=4.5.2
Severity: critical
Prototype Pollution - https://npmjs.com/advisories/1164
Arbitrary Code Execution - https://npmjs.com/advisories/1316
Arbitrary Code Execution - https://npmjs.com/advisories/1324
Cross-Site Scripting - https://npmjs.com/advisories/61
Prototype Pollution - https://npmjs.com/advisories/755
Depends on vulnerable versions of uglify-js
fix available via `npm audit fix --force`
Will install cssnext-loader@0.2.0, which is a breaking change
node_modules/handlebars
  directory-encoder  *
  Depends on vulnerable versions of handlebars
  Depends on vulnerable versions of img-stats
  Depends on vulnerable versions of lodash
  node_modules/directory-encoder
    postcss-url  1.3.1 - 5.1.2
    Depends on vulnerable versions of directory-encoder
    node_modules/postcss-url
      cssnext  >=1.0.0
      Depends on vulnerable versions of postcss-url
      node_modules/cssnext
        cssnext-loader  >=1.0.0
        Depends on vulnerable versions of cssnext
        node_modules/cssnext-loader

lodash  <=4.17.18
Severity: high
Prototype Pollution - https://npmjs.com/advisories/1065
Prototype Pollution - https://npmjs.com/advisories/1523
Prototype Pollution - https://npmjs.com/advisories/577
Prototype Pollution - https://npmjs.com/advisories/782
fix available via `npm audit fix --force`
Will install babel@6.23.0, which is a breaking change
node_modules/directory-encoder/node_modules/lodash
node_modules/lodash
  babel  4.0.1 - 5.8.38
  Depends on vulnerable versions of babel-core
  Depends on vulnerable versions of lodash
  node_modules/babel
  babel-core  <=6.9.1
  Depends on vulnerable versions of babel-plugin-proto-to-assign
  Depends on vulnerable versions of lodash
  Depends on vulnerable versions of minimatch
  node_modules/babel-core
    babel-eslint  2.0.0 - 4.1.8
    Depends on vulnerable versions of babel-core
    node_modules/babel-eslint
    babel-loader  <=5.4.2
    Depends on vulnerable versions of babel-core
    node_modules/babel-loader
  babel-plugin-proto-to-assign  *
  Depends on vulnerable versions of lodash
  node_modules/babel-plugin-proto-to-assign
  directory-encoder  *
  Depends on vulnerable versions of handlebars
  Depends on vulnerable versions of img-stats
  Depends on vulnerable versions of lodash
  node_modules/directory-encoder
    postcss-url  1.3.1 - 5.1.2
    Depends on vulnerable versions of directory-encoder
    node_modules/postcss-url
      cssnext  >=1.0.0
      Depends on vulnerable versions of postcss-url
      node_modules/cssnext
        cssnext-loader  >=1.0.0
        Depends on vulnerable versions of cssnext
        node_modules/cssnext-loader
  inquirer  <=0.11.4
  Depends on vulnerable versions of lodash
  node_modules/inquirer
    eslint  0.7.1 - 2.0.0
    Depends on vulnerable versions of inquirer
    Depends on vulnerable versions of minimatch
    node_modules/eslint
      eslint-loader  <=0.14.2
      Depends on vulnerable versions of eslint
      node_modules/eslint-loader

minimatch  <=3.0.1
Severity: high
Regular Expression Denial of Service - https://npmjs.com/advisories/118
fix available via `npm audit fix --force`
Will install eslint@7.23.0, which is a breaking change
node_modules/minimatch
  babel-core  <=6.9.1
  Depends on vulnerable versions of babel-plugin-proto-to-assign
  Depends on vulnerable versions of lodash
  Depends on vulnerable versions of minimatch
  node_modules/babel-core
    babel  4.0.1 - 5.8.38
    Depends on vulnerable versions of babel-core
    Depends on vulnerable versions of lodash
    node_modules/babel
    babel-eslint  2.0.0 - 4.1.8
    Depends on vulnerable versions of babel-core
    node_modules/babel-eslint
    babel-loader  <=5.4.2
    Depends on vulnerable versions of babel-core
    node_modules/babel-loader
  eslint  0.7.1 - 2.0.0
  Depends on vulnerable versions of inquirer
  Depends on vulnerable versions of minimatch
  node_modules/eslint
    eslint-loader  <=0.14.2
    Depends on vulnerable versions of eslint
    node_modules/eslint-loader

minimist  <0.2.1 || >=1.0.0 <1.2.3
Prototype Pollution - https://npmjs.com/advisories/1179
fix available via `npm audit fix --force`
Will install webpack@5.28.0, which is a breaking change
node_modules/webpack/node_modules/minimist
  optimist  >=0.6.0
  Depends on vulnerable versions of minimist
  node_modules/webpack/node_modules/optimist
    webpack  0.11.0-beta1 - 2.0.2-beta
    Depends on vulnerable versions of optimist
    node_modules/webpack

parsejson  *
Severity: high
Regular Expression Denial of Service - https://npmjs.com/advisories/528
fix available via `npm audit fix --force`
Will install socket.io-client@4.0.0, which is a breaking change
node_modules/parsejson
  engine.io-client  <=3.1.1
  Depends on vulnerable versions of debug
  Depends on vulnerable versions of parsejson
  node_modules/engine.io-client
    socket.io-client  1.0.0-pre - 2.0.1
    Depends on vulnerable versions of debug
    Depends on vulnerable versions of engine.io-client
    node_modules/socket.io-client
      socket.io  <=2.3.0
      Depends on vulnerable versions of debug
      Depends on vulnerable versions of socket.io-client
      node_modules/socket.io

socket.io  <=2.3.0
Severity: moderate
Insecure Default Configuration - https://npmjs.com/advisories/1609
Depends on vulnerable versions of debug
Depends on vulnerable versions of socket.io-client
fix available via `npm audit fix --force`
Will install socket.io@4.0.0, which is a breaking change
node_modules/socket.io

uglify-js  <=2.5.0
Incorrect Handling of Non-Boolean Comparisons During Minification - https://npmjs.com/advisories/39
Regular Expression Denial of Service - https://npmjs.com/advisories/48
fix available via `npm audit fix --force`
Will install cssnext-loader@0.2.0, which is a breaking change
node_modules/uglify-js
  handlebars  <=4.5.2
  Depends on vulnerable versions of uglify-js
  node_modules/handlebars
    directory-encoder  *
    Depends on vulnerable versions of handlebars
    Depends on vulnerable versions of img-stats
    Depends on vulnerable versions of lodash
    node_modules/directory-encoder
      postcss-url  1.3.1 - 5.1.2
      Depends on vulnerable versions of directory-encoder
      node_modules/postcss-url
        cssnext  >=1.0.0
        Depends on vulnerable versions of postcss-url
        node_modules/cssnext
          cssnext-loader  >=1.0.0
          Depends on vulnerable versions of cssnext
          node_modules/cssnext-loader

xmldom  <0.5.0
Misinterpretation of malicious XML input - https://npmjs.com/advisories/1650
fix available via `npm audit fix --force`
Will install cssnext-loader@0.2.0, which is a breaking change
node_modules/xmldom
  img-stats  >=0.3.0
  Depends on vulnerable versions of xmldom
  node_modules/img-stats
    directory-encoder  *
    Depends on vulnerable versions of handlebars
    Depends on vulnerable versions of img-stats
    Depends on vulnerable versions of lodash
    node_modules/directory-encoder
      postcss-url  1.3.1 - 5.1.2
      Depends on vulnerable versions of directory-encoder
      node_modules/postcss-url
        cssnext  >=1.0.0
        Depends on vulnerable versions of postcss-url
        node_modules/cssnext
          cssnext-loader  >=1.0.0
          Depends on vulnerable versions of cssnext
          node_modules/cssnext-loader

33 vulnerabilities (15 low, 1 moderate, 12 high, 5 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

```